### PR TITLE
feat: add briefingName overwrite

### DIFF
--- a/.github/USAGE.md
+++ b/.github/USAGE.md
@@ -32,17 +32,22 @@ You can also use [Steamcmd](https://developer.valvesoftware.com/wiki/SteamCMD) t
 
 **Required.** Path to a directory where the action will put the pbo file, relative to the repository root.
 
+### `briefingName`
+
+**Optional.** If not empty, this value will overwrite the mission's briefingName value before building the pbo. Double quotes (") are ignored to prevent injection. Usefull to inject versioning information such as version number of commit ref.
+
 ## Outputs
 
 *There is no output*
 
 ## Example
 
-This example will pack content of `missions/Orion.Malden` into `output/Orion.Malden.pbo` :
+This example will rename the mission to `Orion main` and pack content of `missions/Orion.Malden` into `output/Orion.Malden.pbo` :
 
 ```yml
-uses: team-gsri/actions-build-mission@1.0.0
+uses: team-gsri/actions-build-mission@0.1.0
 with:
+  briefingName: Orion ${{ gitbub.ref_name }}
   source: 'missions/Orion.Malden'
   target: 'output'
 ```

--- a/New-MissionPbo.ps1
+++ b/New-MissionPbo.ps1
@@ -8,8 +8,13 @@ param (
     [Parameter(Mandatory)]
     [ValidateScript({ if (Test-Path $_ -PathType Container) { $true } else { Throw '-Target must ba a valid directory' } })]
     [string]
-    $Target
+    $Target,
+
+    [Parameter()]
+    [string]
+    $BriefingName = ''
 )
+
 Begin {
     if (-Not (Test-Path -Path ${env:ARMA3TOOLS} -PathType Container)) {
         Throw 'Arma 3 Tools not found'
@@ -27,8 +32,16 @@ Begin {
         Throw 'mission.sqm file not found'
     }
     $Source = Resolve-Path $Source.TrimEnd('/\')
+    $BriefingName = $BriefingName -Replace ( '"', '' )
 }
+
 Process {
+    if($BriefingName -ne '') {
+        $(Get-Content $missionFilename) -Replace (
+            'briefingName="[^"]*";',
+            "briefingName=""$BriefingName"";"
+        ) | Set-Content -LiteralPath $missionFilename
+    }
     & $cfgConvertExe -bin -dst "$missionFilename" "$missionFilename"
     & $fileBankExe -dst $Target $Source
 }

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,11 @@ inputs:
     description: 'Path to the directory where the action will output the pbo file'
     required: true
 
+  briefingName:
+    description: 'If not empty, will overwrite the mission briefingName before building the pbo'
+    required: false
+    default: ''
+
 runs:
   using: composite
   steps:
@@ -18,6 +23,7 @@ runs:
       run: |
         $ActionArgs = @{
           Source = Join-Path -Path ${env:GITHUB_WORKSPACE} -ChildPath '${{ inputs.source }}'
-          Target = Join-Path -Path ${env:GITHUB_WORKSPACE} -ChildPath '${{ inputs.target }}' 
+          Target = Join-Path -Path ${env:GITHUB_WORKSPACE} -ChildPath '${{ inputs.target }}'
+          BriefingName = ${{ inputs.briefingName }}
         }
         ${{ github.action_path }}/New-MissionPbo.ps1 @ActionArgs


### PR DESCRIPTION
This PR adds the ability to overwrite the briefingName property of the mission.

Fix #1 